### PR TITLE
画像プレビュー機能の実装

### DIFF
--- a/app/assets/stylesheets/articles/new.css
+++ b/app/assets/stylesheets/articles/new.css
@@ -9,14 +9,27 @@
   align-items: center;
 }
 
+.article-icon {
+  margin-left: 5px;
+}
+
 .article-image {
   width: 100%;
   margin: 20px 40px;
 }
 
+.image-message {
+  margin-left: 5px;
+}
+
 .article-title {
   width: 100%;
+  margin-top: 15px;
   margin-bottom: 15px;
+}
+
+.previews {
+  text-align: center;
 }
 
 .article-content {

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -4,9 +4,10 @@
 // that code so it'll be compiled.
 
 require("@rails/ujs").start()
-require("turbolinks").start()
+// require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
+require('../preview')
 import "bootstrap"
 import "../stylesheets/application"
 import '@fortawesome/fontawesome-free/js/all';

--- a/app/javascript/preview.js
+++ b/app/javascript/preview.js
@@ -1,0 +1,32 @@
+document.addEventListener('DOMContentLoaded', function(){
+  // 新規投稿・編集ページのフォームを取得
+  const postForm = document.getElementById('new_post');
+  // プレビューを表示するためのスペースを取得
+  const previewList = document.getElementById('previews');
+  // 新規投稿・編集ページのフォームがないならここで終了。「!」は論理否定演算子。
+  if (!postForm) return null;
+
+  // input要素を取得
+  const fileField = document.querySelector('input[type="file"][name="article[image]"]');
+  // input要素で値の変化が起きた際に呼び出される関数
+  fileField.addEventListener('change', function(e){
+    // 古いプレビューが存在する場合は削除
+    const alreadyPreview = document.querySelector('.preview');
+    if (alreadyPreview) {
+      alreadyPreview.remove();
+    };
+    const file = e.target.files[0];
+    const blob = window.URL.createObjectURL(file);
+    // 画像を表示するためのdiv要素を生成
+    const previewWrapper = document.createElement('div');
+    previewWrapper.setAttribute('class', 'preview');
+    // 表示する画像を生成
+    const previewImage = document.createElement('img');
+    previewImage.setAttribute('class', 'preview-image');
+    previewImage.setAttribute('src', blob);
+
+    // 生成したHTMLの要素をブラウザに表示させる
+    previewWrapper.appendChild(previewImage);
+    previewList.appendChild(previewWrapper);
+  });
+});

--- a/app/views/shared/_post.html.erb
+++ b/app/views/shared/_post.html.erb
@@ -1,10 +1,10 @@
 <div class="new-article">
   <div class="article-form">
-    <%= form_with model: @article, local: true do |f| %>
+    <%= form_with model: @article, id: 'new_post', local: true do |f| %>
       
       <%= render 'shared/error_messages', model: f.object %>
 
-      <div class="article-genre">
+      <div class="genre-image">
         <div class="genre-headline">
           ⚫️どのチームに関する記事ですか？
         </div>
@@ -14,10 +14,17 @@
           </div>
           <div class="article-image">
             <label class="form-image">
-              <i class="fa-solid fa-image fa-2xl"></i>
+              <i class="fa-solid fa-image fa-2xl article-icon"></i>
               <%= f.file_field :image, class: "image-form" %>
+              <% if @article.image.present? %>
+                <span class="image-message">画像を変更</span>
+              <% else %>
+                <span class="image-message">画像が選択されていません</span>
+              <% end %>
             </label>
           </div>
+        </div>
+        <div id="previews" class="previews">
         </div>
       </div>
       <div class="article-title">


### PR DESCRIPTION
# What
投稿しようとしている記事に添付されている記事をプレビュー表示する機能を実装。

# Why
ユーザーが記事の新規投稿および記事の編集をしようとした際に、画像をプレビュー表示させて添付したい画像を見ることができるようにするため。