### PR TITLE
投稿時刻の日本語化を実装

### DIFF
--- a/app/views/shared/_article.html.erb
+++ b/app/views/shared/_article.html.erb
@@ -21,7 +21,7 @@
           </div>
         <% end %>
         <div class="post-date">
-          投稿日時：<%= article.created_at %>
+          投稿日時：<%= l article.created_at %>
         </div>
       </div>
     </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,7 +10,8 @@ module ShareMlb
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
-
+    config.i18n.default_locale = :ja
+    config.time_zone = 'Tokyo'
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,4 @@
+ja:
+  time:
+    formats:
+      default: "%Y/%m/%d %H:%M:%S"


### PR DESCRIPTION
# What
記事の投稿時刻を日本時間表記にする機能を実装。

# Why
ユーザーは日本人を想定しているので日本時間表記にした方がわかりやすいため。