### PR TITLE
チーム別検索機能を実装

### DIFF
--- a/app/assets/stylesheets/articles/index.scss
+++ b/app/assets/stylesheets/articles/index.scss
@@ -34,26 +34,75 @@
 // 記事一覧エリア
 .main-contents {
   width: 100%;
-  padding: 30px 150px 70px;
+  padding: 30px 80px 70px;
   background-color: #f0f0f0;
+  display: flex;
+  justify-content: space-between;
+}
+
+.main-left {
+  width: 20%;
+  padding-right: 20px;
+}
+
+.side-bar {
+  text-align: center;
+}
+
+.team-sort-headline {
+  font-size: 18px;
+  font-weight: 600;
+  margin-bottom: 10px;
+}
+
+.team-search-form {
+  width: 100%;
+  height: 50px;
+  font-weight: 600;
+  border: none;
+  border-radius: 5px;
+  text-align: center;
+}
+
+.team-search-btn-box {
+  width: 100%;
+  margin-top: 20px;
+}
+
+.team-search-btn {
+  width: 100%;
+  height: 30px;
+  font-weight: 600;
+  border: none;
+  border-radius: 5px;
+  background-color: black;
+  color: white;
+}
+
+.main-right {
+  width: 80%;
 }
 
 .headline-search {
   display: flex;
+  width: 100%;
+  padding: 30px 80px;
+  background-color: #f0f0f0;
 }
 
 .articles-headline {
+  width: 30%;
   margin-bottom: 20px;
   font-size: 30px;
   font-weight: 600;
 }
 
 .search {
-  margin-left: 50px;
+  width: 70%;
 }
 
 .search-input {
-  width: 300px;
+  width: 60%;
   padding: 2px 10px;
   border: none;
   border-radius: 10px;

--- a/app/assets/stylesheets/articles/search.css
+++ b/app/assets/stylesheets/articles/search.css
@@ -39,3 +39,23 @@
   font-size: 25px;
   font-weight: 600;
 }
+
+/* チーム別検索画面 */
+
+.team-search-main {
+  width: 100%;
+  flex-grow: 1;
+  padding: 40px 150px 70px;
+  background-color: #f0f0f0;
+}
+
+.team-search-headline {
+  font-size: 30px;
+  font-weight: 600;
+  margin-bottom: 20px;
+}
+
+.team-search-sub-message {
+  font-size: 20px;
+  margin-bottom: 20px;
+}

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -5,6 +5,7 @@ class ArticlesController < ApplicationController
   def index
     @articles = Article.includes(:user)
     @articles = Article.page(params[:page]).per(5).order('created_at DESC')
+    @team_names = Team.first(31)
   end
 
   def new
@@ -45,6 +46,11 @@ class ArticlesController < ApplicationController
   def search
     @articles = Article.search(params[:keyword]).page(params[:page]).per(3).order('created_at DESC')
     @keyword = params[:keyword]
+  end
+
+  def team_search
+    @team = Team.find(params[:team_id])
+    @articles = Article.where(team_id: params[:team_id]).page(params[:page]).per(1).order('created_at DESC')
   end
 
   private

--- a/app/javascript/article.js
+++ b/app/javascript/article.js
@@ -189,6 +189,17 @@ document.addEventListener('DOMContentLoaded', function(){
       followers.setAttribute("style", "display: block;");
     });
   });
+
+  // チーム別検索ボタン
+  const sidebarBtn = document.getElementById("side-bar-btn");
+  if (!sidebarBtn) return null;
+
+  sidebarBtn.addEventListener('mouseover', function() {
+    this.setAttribute("style", "background-color: #666666;");
+  });
+  sidebarBtn.addEventListener('mouseout', function() {
+    this.removeAttribute("style", "background-color: #666666;");
+  });
   
   // 記事本文の一部選択
   // function selection(event) {

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -7,30 +7,47 @@
       MLBをより身近に
     </div>
   </div>
+  <div class="headline-search">
+    <div class="articles-headline">
+      投稿記事一覧
+      <i class="fa-solid fa-newspaper"></i>
+    </div>
+    <div class="search">
+      <%= form_with(url: search_articles_path, local: true, method: :get, class: "search-form") do |f| %>
+        <%= f.text_field :keyword, placeholder: "キーワードで検索", class: "search-input" %>
+        <%= f.submit "検索", class: "search-btn" %>
+      <% end %>
+    </div>
+  </div>
   <div class="main-contents">
-    <div class="headline-search">
-      <div class="articles-headline">
-        投稿記事一覧
-        <i class="fa-solid fa-newspaper"></i>
-      </div>
-      <div class="search">
-        <%= form_with(url: search_articles_path, local: true, method: :get, class: "search-form") do |f| %>
-          <%= f.text_field :keyword, placeholder: "キーワードで検索", class: "search-input" %>
-          <%= f.submit "検索", class: "search-btn" %>
-        <% end %>
+    <div class="main-left">
+      <div class="side-bar">
+        <div class="team-sort-headline">
+          チーム別検索
+        </div>
+        <div class="team-box">
+          <%= form_with(url: team_search_articles_path, local: true, method: :get, class: "team-search-form") do |f| %>
+            <%= f.collection_select(:team_id, Team.first(31), :id, :name, {}, {id:"item-category", class: "team-search-form"}) %>
+            <div class="team-search-btn-box">
+              <%= f.submit "検索", class: "team-search-btn", id: "side-bar-btn" %>
+            </div>
+          <% end %>
+        </div>
       </div>
     </div>
-    <div class="main-articles">
-      <% if @articles.present? %>
-        <%= render partial: "shared/article", collection: @articles %>
-        <div class="pagination">
-          <%= paginate @articles %>
-        </div>
-      <% else %>
-        <div class="no-articles">
-          投稿された記事がありません
-        </div>
-      <% end %>
+    <div class="main-right">
+      <div class="main-articles">
+        <% if @articles.present? %>
+          <%= render partial: "shared/article", collection: @articles %>
+          <div class="pagination">
+            <%= paginate @articles %>
+          </div>
+        <% else %>
+          <div class="no-articles">
+            投稿された記事がありません
+          </div>
+        <% end %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/articles/team_search.html.erb
+++ b/app/views/articles/team_search.html.erb
@@ -1,0 +1,26 @@
+<%= render "shared/header" %>
+
+<div class="team-search-main">
+  <div class="team-search-headline">
+    <%= @team.name %>に関する記事
+    <i class="fa-solid fa-newspaper"></i>
+  </div>
+  <div class="team-search-articles">
+    <% if @articles.present? %>
+      <div class="team-search-sub-message">
+        <%= @articles.length %>件見つかりました
+        <i class="fa-solid fa-magnifying-glass"></i>
+      </div>
+      <%= render partial: "shared/article", collection: @articles %>
+      <div class="pagination">
+        <%= paginate @articles %>
+      </div>
+    <% else %>
+      <div class="no-articles">
+        投稿された記事がありません
+      </div>
+    <% end %>
+  </div>
+</div>
+
+<%= render "shared/footer" %>

--- a/app/views/shared/_article.html.erb
+++ b/app/views/shared/_article.html.erb
@@ -4,7 +4,7 @@
       <%= link_to article.title, article_path(article), class: "title-link" %>
     </div>
     <div class="team">
-      関連するチーム：<%= link_to article.team.name, "#", class: "team-link teams" %>
+      関連するチーム：<%= article.team.name %>
     </div>
     <div class="post-like" id="like-btn<%= article.id %>">
       <%= render partial: "shared/like", locals: { article: article } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,9 @@ Rails.application.routes.draw do
     collection do
       get 'search'
     end
+    collection do
+      get 'team_search'
+    end
     resource :likes, only: [:create, :destroy]
   end
   resources :articles, only: [:new, :create, :show, :edit, :update, :destroy]


### PR DESCRIPTION
# What
トップページのサイドバーにあるプルダウンメニューからチームを選択して検索すると、そのチームに関連する記事を表示する機能を実装。

# Why
ユーザーがチーム別に記事を検索できるようにするため。
